### PR TITLE
ANA-13001: Upgrade Ruby requirement to >= 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+ruby ">= 3.3"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'


### PR DESCRIPTION
Ruby 2.6 reached end-of-life on 2022-03-31 and no longer receives security updates. Ruby 3.3 is the lowest version currently receiving security patches.